### PR TITLE
Fix the energy value for recipes with more than 1 unit of output

### DIFF
--- a/production-score.lua
+++ b/production-score.lua
@@ -45,7 +45,7 @@ local function get_product_list()
         for j, ingredient in pairs (ingredients) do
           recipe_ingredients[ingredient.name] = ((ingredient.amount)/#products) / product_amount
         end
-        recipe_ingredients.energy = recipe_prototype.energy
+        recipe_ingredients.energy = recipe_prototype.energy / #products / product_amount
         table.insert(product_list[product.name], recipe_ingredients)
       end
     end


### PR DESCRIPTION
Syrcan found out a bug where recipes that had more than 1 unit of output would have way bigger scores than they should.

Turns out it was cause the energy addition was not taking into account the distribution.