### PR TITLE
Change the output distribution factor

### DIFF
--- a/production-score.lua
+++ b/production-score.lua
@@ -35,6 +35,12 @@ local function get_product_list()
   for recipe_name, recipe_prototype in pairs (recipes) do
     local ingredients = recipe_prototype.ingredients
     local products = recipe_prototype.products
+    local total_products_amount = 0.0
+    for k, product in pairs(products) do
+      local total_product_amount = product.amount or product.probability * ((product.amount_min + product.amount_max) / 2) or 1
+
+      total_products_amount = total_products_amount + total_product_amount
+    end
     for k, product in pairs (products) do
       if not product_list[product.name] then
         product_list[product.name] = {}
@@ -43,7 +49,7 @@ local function get_product_list()
       local product_amount = product.amount or product.probability * ((product.amount_min + product.amount_max) / 2) or 1
       if product_amount > 0 then
         for j, ingredient in pairs (ingredients) do
-          recipe_ingredients[ingredient.name] = ((ingredient.amount)/#products) / product_amount
+          recipe_ingredients[ingredient.name] = (ingredient.amount * (product_amount / total_products_amount)) / product_amount
         end
         recipe_ingredients.energy = recipe_prototype.energy
         table.insert(product_list[product.name], recipe_ingredients)


### PR DESCRIPTION
For some recipes (mainly oil) with more than 1 output, every output was being treated as if they had the same weight, that made some recipes go really negative.

This fixes it by taking into account the output distribution. It can also be combined with #1  by changing it to the same formula used here

It has the issue (not existing in vanilla) where a recipe with both items and fluids would undervalue the item a lot, as every unit is considered the same